### PR TITLE
Fixed issue with guests not being able to see files

### DIFF
--- a/Block/Attachment.php
+++ b/Block/Attachment.php
@@ -183,6 +183,9 @@ class Attachment extends \Magento\Framework\View\Element\Template
      */
     public function getCustomerId()
     {
+        if (!$this->customerSession->isLoggedIn()) {
+            return 0;
+        }
         $customerId = $this->customerSession->getCustomer()->getGroupId();
         return $customerId;
     }


### PR DESCRIPTION
Magento $session->getCustomer()->getGroupId(); returns 1 even if the user is not logged in. This is a simple workaround to see if the user is logged in first, otherwise return 0 which is the correct group ID of guests.