### PR TITLE
ACL overhaul

### DIFF
--- a/Block/Adminhtml/Productattach/Edit.php
+++ b/Block/Adminhtml/Productattach/Edit.php
@@ -87,7 +87,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
             $this->buttonList->remove('save');
         }
 
-        if ($this->_isAllowedAction('Prince_Productattach::productattach_delete')) {
+        if ($this->_isAllowedAction('Prince_Productattach::delete')) {
             $this->buttonList->update('delete', 'label', __('Delete Productattach'));
         } else {
             $this->buttonList->remove('delete');

--- a/Controller/Adminhtml/Fileicon.php
+++ b/Controller/Adminhtml/Fileicon.php
@@ -32,7 +32,7 @@ abstract class Fileicon extends \Magento\Backend\App\Action
 {
 
     protected $_coreRegistry;
-    const ADMIN_RESOURCE = 'Prince_Productattach::productattach_manage';
+    const ADMIN_RESOURCE = 'Prince_Productattach::manage';
 
     /**
      * @param \Magento\Backend\App\Action\Context $context
@@ -53,7 +53,7 @@ abstract class Fileicon extends \Magento\Backend\App\Action
      */
     public function initPage($resultPage)
     {
-        $resultPage->setActiveMenu(self::ADMIN_RESOURCE)
+        $resultPage->setActiveMenu('Prince_Productattach::prince_productattach_fileicon')
             ->addBreadcrumb(__('Prince'), __('Prince'))
             ->addBreadcrumb(__('Fileicon'), __('Fileicon'));
         return $resultPage;

--- a/Controller/Adminhtml/Fileicon/Delete.php
+++ b/Controller/Adminhtml/Fileicon/Delete.php
@@ -44,6 +44,16 @@ class Delete extends \Prince\Productattach\Controller\Adminhtml\Fileicon
     }
 
     /**
+     * Check admin permissions for this controller
+     *
+     * @return boolean
+     */
+    public function _isAllowed()
+    {
+        return $this->_authorization->isAllowed('Prince_Productattach::delete');
+    }
+
+    /**
      * Delete action
      *
      * @return \Magento\Framework\Controller\ResultInterface

--- a/Controller/Adminhtml/Fileicon/Index.php
+++ b/Controller/Adminhtml/Fileicon/Index.php
@@ -48,6 +48,16 @@ class Index extends \Magento\Backend\App\Action
     }
 
     /**
+     * Check admin permissions for this controller
+     *
+     * @return boolean
+     */
+    public function _isAllowed()
+    {
+        return $this->_authorization->isAllowed('Prince_Productattach::manage');
+    }
+
+    /**
      * Index action
      *
      * @return \Magento\Framework\Controller\ResultInterface

--- a/Controller/Adminhtml/Fileicon/InlineEdit.php
+++ b/Controller/Adminhtml/Fileicon/InlineEdit.php
@@ -52,6 +52,16 @@ class InlineEdit extends \Magento\Backend\App\Action
     }
 
     /**
+     * Check admin permissions for this controller
+     *
+     * @return boolean
+     */
+    public function _isAllowed()
+    {
+        return $this->_authorization->isAllowed('Prince_Productattach::save');
+    }
+
+    /**
      * Inline edit action
      *
      * @return \Magento\Framework\Controller\ResultInterface

--- a/Controller/Adminhtml/Fileicon/NewAction.php
+++ b/Controller/Adminhtml/Fileicon/NewAction.php
@@ -48,6 +48,16 @@ class NewAction extends \Prince\Productattach\Controller\Adminhtml\Fileicon
     }
 
     /**
+     * Check admin permissions for this controller
+     *
+     * @return boolean
+     */
+    public function _isAllowed()
+    {
+        return $this->_authorization->isAllowed('Prince_Productattach::save');
+    }
+
+    /**
      * New action
      *
      * @return \Magento\Framework\Controller\ResultInterface

--- a/Controller/Adminhtml/Fileicon/Save.php
+++ b/Controller/Adminhtml/Fileicon/Save.php
@@ -54,6 +54,16 @@ class Save extends \Magento\Backend\App\Action
     }
 
     /**
+     * Check admin permissions for this controller
+     *
+     * @return boolean
+     */
+    public function _isAllowed()
+    {
+        return $this->_authorization->isAllowed('Prince_Productattach::save');
+    }
+
+    /**
      * Save action
      *
      * @return \Magento\Framework\Controller\ResultInterface

--- a/Controller/Adminhtml/Fileicon/Upload.php
+++ b/Controller/Adminhtml/Fileicon/Upload.php
@@ -61,7 +61,7 @@ class Upload extends \Magento\Backend\App\Action
      */
     public function _isAllowed()
     {
-        return $this->_authorization->isAllowed('Prince_Productattach::Fileicon');
+        return $this->_authorization->isAllowed('Prince_Productattach::save');
     }
 
     /**

--- a/Controller/Adminhtml/Index/Delete.php
+++ b/Controller/Adminhtml/Index/Delete.php
@@ -54,7 +54,7 @@ class Delete extends \Magento\Backend\App\Action
      */
     public function _isAllowed()
     {
-        return $this->_authorization->isAllowed('Prince_Productattach::productattach_delete');
+        return $this->_authorization->isAllowed('Prince_Productattach::delete');
     }
 
     /**

--- a/Controller/Adminhtml/Index/DeleteFile.php
+++ b/Controller/Adminhtml/Index/DeleteFile.php
@@ -70,7 +70,7 @@ class DeleteFile extends \Magento\Backend\App\Action
      */
     public function _isAllowed()
     {
-        return $this->_authorization->isAllowed('Prince_Productattach::productattach_deletefile');
+        return $this->_authorization->isAllowed('Prince_Productattach::delete');
     }
 
     /**

--- a/Controller/Adminhtml/Index/Edit.php
+++ b/Controller/Adminhtml/Index/Edit.php
@@ -80,7 +80,7 @@ class Edit extends \Magento\Backend\App\Action
 
     public function _isAllowed()
     {
-        return $this->_authorization->isAllowed('Prince_Productattach::save');
+        return $this->_authorization->isAllowed('Prince_Productattach::manage');
     }
 
     /**

--- a/Controller/Adminhtml/Index/Index.php
+++ b/Controller/Adminhtml/Index/Index.php
@@ -61,7 +61,7 @@ class Index extends \Magento\Backend\App\Action
      */
     public function _isAllowed()
     {
-        return $this->_authorization->isAllowed('Prince_Productattach::productattach_manage');
+        return $this->_authorization->isAllowed('Prince_Productattach::manage');
     }
 
     /**

--- a/Controller/Adminhtml/Index/MassDelete.php
+++ b/Controller/Adminhtml/Index/MassDelete.php
@@ -59,6 +59,14 @@ class MassDelete extends \Magento\Backend\App\Action
         parent::__construct($context);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function _isAllowed()
+    {
+        return $this->_authorization->isAllowed('Prince_Productattach::delete');
+    }
+
     public function execute()
     {
         try {

--- a/Controller/Adminhtml/Index/Products.php
+++ b/Controller/Adminhtml/Index/Products.php
@@ -60,7 +60,7 @@ class Products extends \Magento\Backend\App\Action
      */
     public function _isAllowed()
     {
-        return true;
+        return $this->_authorization->isAllowed('Prince_Productattach::manage');
     }
 
     /**

--- a/Controller/Adminhtml/Index/ProductsGrid.php
+++ b/Controller/Adminhtml/Index/ProductsGrid.php
@@ -61,7 +61,7 @@ class ProductsGrid extends \Magento\Backend\App\Action
      */
     public function _isAllowed()
     {
-        return true;
+        return $this->_authorization->isAllowed('Prince_Productattach::manage');
     }
 
     /**

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -3,16 +3,16 @@
     <acl>
         <resources>
             <resource id="Magento_Backend::admin">
-                <resource id="Prince_Productattach::productattach" title="Productattach" sortOrder="40">
-                    <resource id="Prince_Productattach::manage" title="Productattach Module" sortOrder="10">
-                        <resource id="Prince_Productattach::save" title="Save Productattach" sortOrder="10" />
-                        <resource id="Prince_Productattach::news_delete" title="Delete Productattach" sortOrder="20" />
+                <resource id="Magento_Catalog::catalog">
+                    <resource id="Prince_Productattach::manage" title="Product Attachments" sortOrder="40">
+                        <resource id="Prince_Productattach::save" title="Save" sortOrder="10" />
+                        <resource id="Prince_Productattach::delete" title="Delete" sortOrder="20" />
                     </resource>
                 </resource>
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config">
-                            <resource id="Prince_Productattach::config_productattach" title="Productattach Section" sortOrder="50" />
+                            <resource id="Prince_Productattach::config_productattach" title="Product Attachment Section" sortOrder="50" />
                         </resource>
                     </resource>
                 </resource>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
-        <add id="Prince_Productattach::top_level" title="Product Attachments" module="Prince_Productattach" sortOrder="30" resource="Prince_Productattach::productattach" parent="Magento_Catalog::catalog"/>
-        <add id="Prince_Productattach::productattach_manage" title="Manage Attachments" module="Prince_Productattach" sortOrder="10" parent="Prince_Productattach::top_level" action="productattach/index/" resource="Magento_Backend::content"/>
-        <add id="Prince_Productattach::prince_productattach_fileicon" action="productattach/fileicon/index" module="Prince_Productattach" parent="Prince_Productattach::top_level" resource="Magento_Backend::content" sortOrder="20" title="Manage Icons"/>
+        <add id="Prince_Productattach::top_level" title="Product Attachments" module="Prince_Productattach" sortOrder="30" resource="Prince_Productattach::manage" parent="Magento_Catalog::catalog"/>
+        <add id="Prince_Productattach::productattach_manage" title="Manage Attachments" module="Prince_Productattach" sortOrder="10" parent="Prince_Productattach::top_level" action="productattach/index/" resource="Prince_Productattach::manage"/>
+        <add id="Prince_Productattach::prince_productattach_fileicon" action="productattach/fileicon/index" module="Prince_Productattach" parent="Prince_Productattach::top_level" resource="Prince_Productattach::manage" sortOrder="20" title="Manage Icons"/>
     </menu>
 </config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -8,7 +8,7 @@
             <class>separator-top</class>
             <label>Product Attachment</label>
             <tab>mageprince</tab>
-            <resource>Magento_Backend::content</resource>
+            <resource>Prince_Productattach::config_productattach</resource>
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General Configuration</label>
                 <comment><![CDATA[This feature is an open source module licenced under GPL-3.0, read more on <a href="https://github.com/mageprince/magento2-productAttachment" target="_blank">our GitHub page</a>.]]></comment>


### PR DESCRIPTION
Fixes https://github.com/mageprince/magento2-productAttachment/issues/25

Complete overhaul, there were missing/miss-matched/wrong resources assigned in a lot of places.

A "new" issue now is that if you only have the "manage"-right, all buttons in File-Icon section is still visible, you do however get the "permission denied" screen if you try to save/delete.