### PR TITLE
Updated composer.json, removed version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,18 @@
 {
     "name": "mageprince/magento2-productattachment",
     "description": "Magento2 Product Attachment Module",
+    "homepage": "https://github.com/mageprince/magento2-productAttachment",
     "type": "magento2-module",
-    "version": "1.0.0",
-    "minimum-stability": "dev",
-    "license": "proprietary",
+    "license": "GPL-3.0-or-later",
     "authors": [
         {
           "name": "Prince Patel",
           "email": "mail.mageprince@gmail.com"
         }
     ],
+    "support": {
+        "issues": "https://github.com/mageprince/magento2-productAttachment/issues"
+    },
     "autoload": {
         "files": [
             "registration.php"


### PR DESCRIPTION
* Version should not be checked in, composer figure that out itself with the use of git-tags.
  See https://getcomposer.org/doc/04-schema.md#version
* Removed minimal-stability since that is only for root packages.
* Changed license to GPL-3.0, since that is used in all file headers
* Added hompage and support links