### PR TITLE
Remove bootstrap.js from productattach_index_edit.xml

### DIFF
--- a/view/adminhtml/layout/productattach_index_edit.xml
+++ b/view/adminhtml/layout/productattach_index_edit.xml
@@ -2,7 +2,6 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="jquery/fileUploader/css/jquery.fileupload-ui.css"/>
-        <link src="jquery/fileUploader/bootstrap.js"/>
     </head>
     <update handle="editor"/>
     <body>


### PR DESCRIPTION
jquery/fileUploader/bootstrap.js doesn't exist (anymore?) and it causes an error while trying to add attachment. Removing this line makes it work again,